### PR TITLE
Set up the basic CI infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: rust
+
+cache: pip
+
+install:
+  - bash ci/install.sh
+  - source ~/.cargo/env || true
+
+script:
+  - true
+
+after_success:
+  - bash ci/github_pages.sh
+
+notifications:
+  email:
+    on_success: never

--- a/ci/github_pages.sh
+++ b/ci/github_pages.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+BOOK_DIR=book
+
+# Only upload the built book to github pages if it's a commit to master
+if [ "$TRAVIS_BRANCH" = master -a "$TRAVIS_PULL_REQUEST" = false ]; then
+    mdbook build 
+    ghp-import $BOOK_DIR
+fi

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+
+if command -v ghp-import >/dev/null 2>&1; then
+    pip install ghp-import
+fi


### PR DESCRIPTION
This should set up travis so it'll rebuild the `rustc-guide` whenever there's a commit to master. Unfortunately, I'm not a contributor on this repo so I can't add it to `travis.yml`.

Once we enable travis it may take a couple extra commits to make sure everything is working as desired.

(fixes #1)