### PR TITLE
Fix Github Pages path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ deploy:
   provider: pages
   skip-cleanup: true
   github-token: $GITHUB_TOKEN
-  local-dir: book
+  local-dir: book/html
   on:
     branch: master


### PR DESCRIPTION
The newer version of mdBook uses a different path for the html output.