### PR TITLE
Deleted <a> tag which was messing up the associated types page

### DIFF
--- a/src/appendix-background.md
+++ b/src/appendix-background.md
@@ -4,7 +4,7 @@ This section covers a numbers of common compiler terms that arise in
 this guide. We try to give the general definition while providing some
 Rust-specific context.
 
-<a name=cfg>
+<a name="cfg"></a>
 
 ## What is a control-flow graph?
 
@@ -72,7 +72,7 @@ When using a control-flow graph, a loop simply appears as a cycle in
 the graph, and the `break` keyword translates into a path out of that
 cycle.
 
-<a name=dataflow>
+<a name="dataflow"></a>
 
 ## What is a dataflow analysis?
 
@@ -81,13 +81,13 @@ and Michael I. Schwartzbach is an incredible resource!
 
 *to be written*
 
-<a name=quantified>
+<a name="quantified"></a>
 
 ## What is "universally quantified"? What about "existentially quantified"?
 
 *to be written*
 
-<a name=variance>
+<a name="variance"></a>
 
 ## What is co- and contra-variance?
 
@@ -97,7 +97,7 @@ Check out the subtyping chapter from the
 See the [variance](./variance.html) chapter of this guide for more info on how
 the type checker handles variance.
 
-<a name=free-vs-bound>
+<a name="free-vs-bound"></a>
 
 ## What is a "free region" or a "free variable"? What about "bound region"?
 

--- a/src/conventions.md
+++ b/src/conventions.md
@@ -3,7 +3,7 @@ chapter covers [formatting](#formatting), [coding for correctness](#cc),
 [using crates from crates.io](#cio), and some tips on
 [structuring your PR for easy review](#er).
 
-<a name=formatting>
+<a name="formatting"></a>
 
 # Formatting and the tidy script
 
@@ -16,7 +16,7 @@ in isolation with `./x.py test src/tools/tidy`.
 
 [fmt]: https://github.com/rust-lang-nursery/fmt-rfcs
 
-<a name=copyright>
+<a name="copyright"></a>
 
 ### Copyright notice
 
@@ -57,7 +57,7 @@ the copyright notice) like so:
 
 Prefer 4-space indent.
 
-<a name=cc>
+<a name="cc"></a>
 
 # Coding for correctness
 
@@ -99,7 +99,7 @@ if foo {
 }
 ```
 
-<a name=cio>
+<a name="cio"></a>
 
 # Using crates from crates.io
 
@@ -108,7 +108,7 @@ dependencies should not be added gratuitously. All such crates must
 have a suitably permissive license. There is an automatic check which
 inspects the Cargo metadata to ensure this.
 
-<a name=er>
+<a name="er"></a>
 
 # How to structure your PR
 

--- a/src/incremental-compilation.md
+++ b/src/incremental-compilation.md
@@ -76,7 +76,7 @@ Try-mark-green works as follows:
     - Otherwise, **all** of the nodes in `reads(Q)` must be **green**. In that
       case, we can color Q as **green** and return.
 
-<a name="dag">
+<a name="dag"></a>
 
 ### The query DAG
 

--- a/src/mir-regionck.md
+++ b/src/mir-regionck.md
@@ -51,7 +51,7 @@ the role of `liveness_constraints` vs other `constraints`, plus
 
 *to be written*
 
-<a name=mirtypeck>
+<a name="mirtypeck"></a>
 
 ## The MIR type-check
 
@@ -88,7 +88,7 @@ The kinds of region elements are as follows:
 *to be written* -- describe how we can extend the values of a variable
  with causal tracking etc
 
-<a name=skol>
+<a name="skol"></a>
 
 ## Skolemization and universes
 

--- a/src/mir.md
+++ b/src/mir.md
@@ -234,7 +234,7 @@ but [you can read about those below](#promoted)).
 
 *to be written*
 
-<a name=promoted>
+<a name="promoted"></a>
 
 ### Promoted constants
 

--- a/src/tests/adding.md
+++ b/src/tests/adding.md
@@ -68,7 +68,7 @@ then it might make sense to put the tests in directories like:
 In other cases, there may already be a suitable directory. (The proper
 directory structure to use is actually an area of active debate.)
 
-<a name=explanatory_comment>
+<a name="explanatory_comment"></a>
 
 ## Comment explaining what the test is about
 
@@ -90,7 +90,7 @@ test must be rewritten because it no longer tests what is was meant to
 test, and then it's useful to know what it *was* meant to test
 exactly).
 
-<a name=header_commands>
+<a name="header_commands"></a>
 
 ## Header commands: configuring rustc
 
@@ -167,7 +167,7 @@ source.
 
 [`header.rs`]: https://github.com/rust-lang/rust/tree/master/src/tools/compiletest/src/header.rs
 
-<a name="error_annotations">
+<a name="error_annotations"></a>
 
 ## Error annotations
 
@@ -229,7 +229,7 @@ currently only apply to the test as a whole, not to particular
 revisions. The only headers that are intended to really work when
 customized to a revision are error patterns and compiler flags.
 
-<a name="ui">
+<a name="ui"></a>
 
 ## Guide to the UI tests
 

--- a/src/traits-associated-types.md
+++ b/src/traits-associated-types.md
@@ -22,6 +22,8 @@ though that is something we may want to change in the future.)
 
 [intoiter-item]: https://doc.rust-lang.org/nightly/core/iter/trait.IntoIterator.html#associatedtype.Item
 
+<a name="normalize"></a>
+
 In some cases, associated type projections can be **normalized** --
 that is, simplified -- based on the types given in an impl. So, to
 continue with our example, the impl of `IntoIterator` for `Option<T>`

--- a/src/traits-associated-types.md
+++ b/src/traits-associated-types.md
@@ -22,8 +22,6 @@ though that is something we may want to change in the future.)
 
 [intoiter-item]: https://doc.rust-lang.org/nightly/core/iter/trait.IntoIterator.html#associatedtype.Item
 
-<a name=normalize>
-
 In some cases, associated type projections can be **normalized** --
 that is, simplified -- based on the types given in an impl. So, to
 continue with our example, the impl of `IntoIterator` for `Option<T>`
@@ -152,4 +150,3 @@ to process that constraint.
 variable X and asks us to prove that `ProjectionEq(P1 = X)` and
 `ProjectionEq(P2 = X)`. That used to be needed in an older system to
 prevent cycles; I rather doubt it still is. -nmatsakis)
-

--- a/src/traits-bibliography.md
+++ b/src/traits-bibliography.md
@@ -10,7 +10,7 @@ new every time you open it.
 
 [phl]: https://www.amazon.com/Programming-Higher-Order-Logic-Dale-Miller/dp/052187940X
 
-<a name=pphhf>
+<a name="pphhf"></a>
 
 ["A proof procedure for the logic of Hereditary Harrop formulas"][pphhf],
 by Gopalan Nadathur. This paper covers the basics of universes,
@@ -18,7 +18,7 @@ environments, and Lambda Prolog-style proof search. Quite readable.
 
 [pphhf]: https://dl.acm.org/citation.cfm?id=868380
 
-<a name=slg> 
+<a name="slg"></a> 
 
 ["A new formulation of tabled resolution with delay"][nftrd], by
 [Theresa Swift]. This paper gives a kind of abstract treatment of the

--- a/src/traits-canonical-queries.md
+++ b/src/traits-canonical-queries.md
@@ -95,7 +95,7 @@ Rc<?T>: Clone
 
 After all, `Rc<?T>` is true **no matter what type `?T` is**.
 
-<a name="query-response">
+<a name="query-response"></a>
 
 ## A trait query in rustc
 

--- a/src/traits-goals-and-clauses.md
+++ b/src/traits-goals-and-clauses.md
@@ -39,11 +39,11 @@ gives the details.
 
 [pphhf]: ./traits-bibliography.html#pphhf
 
-<a name="domain-goals">
+<a name="domain-goals"></a>
 
 ## Domain goals
 
-<a name=trait-ref>
+<a name="trait-ref"></a>
 
 To define the set of *domain goals* in our system, we need to first
 introduce a few simple formulations. A **trait reference** consists of
@@ -58,7 +58,7 @@ IntoIterator`. Note that Rust surface syntax also permits some extra
 things, like associated type bindings (`Vec<T>: IntoIterator<Item =
 T>`), that are not part of a trait reference.
 
-<a name=projection>
+<a name="projection"></a>
 
 A **projection** consists of an associated item reference along with
 its inputs P0..Pm:
@@ -105,7 +105,7 @@ DomainGoal = Implemented(TraitRef)
 
 [n]: ./traits-associated-types.html#normalize
 
-<a name=coinductive>
+<a name="coinductive"></a>
 
 ## Coinductive goals
 

--- a/src/traits-lowering-module.md
+++ b/src/traits-lowering-module.md
@@ -18,7 +18,7 @@ returns a vector of program clauses.
 
 [query]: ./query.html
 
-<a name=unit-tests>
+<a name="unit-tests"></a>
 
 ## Unit tests
 

--- a/src/traits-lowering-rules.md
+++ b/src/traits-lowering-rules.md
@@ -94,7 +94,7 @@ forall<Self, P1..Pn> {
 }
 ```
 
-<a name="implied-bounds">
+<a name="implied-bounds"></a>
 
 #### Implied bounds
 
@@ -176,7 +176,7 @@ we must show that `WellFormed(TraitRef)`. This in turn justifies the
 implied bounds rules that allow us to extend the set of `FromEnv`
 items.
 
-<a name=trait-items>
+<a name="trait-items"></a>
 
 ## Lowering trait items
 
@@ -291,7 +291,7 @@ forall<P0..Pm> {
 Note that `WC` and `WC1` both encode where-clauses that the impl can
 rely on.
 
-<a name=constant-vals>
+<a name="constant-vals"></a>
 
 ### Function and constant values
 

--- a/src/type-inference.md
+++ b/src/type-inference.md
@@ -43,7 +43,7 @@ The `tcx.infer_ctxt` method actually returns a builder, which means
 there are some kinds of configuration you can do before the `infcx` is
 created. See `InferCtxtBuilder` for more information.
 
-<a name=vars>
+<a name="vars"></a>
 
 ## Inference variables
 

--- a/src/variance.md
+++ b/src/variance.md
@@ -141,7 +141,7 @@ will wind up being considered green after it is re-evaluated.
 
 [rga]: ./incremental-compilation.html
 
-<a name=addendum>
+<a name="addendum"></a>
 
 ## Addendum: Variance on traits
 


### PR DESCRIPTION
This tag is extra and must have been added mistakenly. Results in the entire rest of the page getting underlined on mouse over for no reason.