### PR TITLE
Update copyright guidance to omit notices for new files.

### DIFF
--- a/src/compiletest.md
+++ b/src/compiletest.md
@@ -63,16 +63,6 @@ header command and the argument list (if present) are typically separated by a
 colon:
 
 ```rust,ignore
-// Copyright 2018 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 // must-compile-successfully
 // failure-status: 1
 

--- a/src/conventions.md
+++ b/src/conventions.md
@@ -20,24 +20,11 @@ in isolation with `./x.py test src/tools/tidy`.
 
 ### Copyright notice
 
-All files must begin with the following copyright notice:
-
-```rust
-// Copyright 2012-2013 The Rust Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution and at
-// http://rust-lang.org/COPYRIGHT.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-```
-
-The year at the top is not meaningful: copyright protections are in
-fact automatic from the moment of authorship. We do not typically edit
-the years on existing files. When creating a new file, you can use the
-current year if you like, but you don't have to.
+Some existing files begin with a copyright and license notice. Please omit this
+notice for new files licensed under the standard terms (dual MIT/Apache-2.0).
+For existing files, the year at the top is not meaningful: copyright
+protections are in fact automatic from the moment of authorship. We do not
+typically edit the years on existing files.
 
 ## Line length
 

--- a/src/tests/adding.md
+++ b/src/tests/adding.md
@@ -101,10 +101,6 @@ this test. For example, this test uses the `// compile-flags` command
 to specify a custom flag to give to rustc when the test is compiled:
 
 ```rust,ignore
-// Copyright 2017 The Rust Project Developers. blah blah blah.
-// ...
-// except according to those terms.
-
 // Test the behavior of `0 - 1` when overflow checks are disabled.
 
 // compile-flags: -Coverflow-checks=off


### PR DESCRIPTION
Previously approved in https://github.com/rust-lang/rust/pull/43498 ;
update the guide to match.