### PR TITLE
Mention incremental compilation in testing chapter

### DIFF
--- a/src/tests/running.md
+++ b/src/tests/running.md
@@ -59,7 +59,27 @@ Under the hood, the test runner invokes the standard rust test runner
 (the same one you get with `#[test]`), so this command would wind up
 filtering for tests that include "issue-1234" in the name.
 
-Often, though, it's easier to just run the test by hand. Most tests are
+## Using incremental compilation
+
+You can further enable the `--incremental` flag to save additional time in subsequent rebuilds:
+
+```bash
+> ./x.py test --stage 1 src/test/ui --incremental --test-args issue-1234
+```
+
+If you don't want to include the flag with every command, you can enable it in the `config.toml`, too:
+
+```toml
+# Whether to always use incremental compilation when building rustc
+incremental = true
+```
+
+Note that incremental compilation will use more disk space than usual. If disk space is a
+concern for you, you might want to check the size of the `build` directory from time to time.
+
+## Running tests manually
+
+Sometimes it's easier and faster to just run the test by hand. Most tests are
 just `rs` files, so you can do something like
 
 ```bash


### PR DESCRIPTION
The `--incremental` flag was only briefly mentioned in [how_to_build_and_run.html][how_to_build_and_run]
so far. Faster testing means faster iteration, happy contributors and perhaps even
more added tests.

[how_to_build_and_run]: https://rust-lang-nursery.github.io/rustc-guide/how-to-build-and-run.html